### PR TITLE
Fmt installation via Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ add_compile_options(-Wall -Wextra -g -Og -fsanitize=undefined)
 
 # --------------------------------------------------------------------
 
-find_package(fmt)
+find_package(fmt QUIET)
 
 if (NOT fmt_FOUND)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.23)
 project(etude)
 
+include(FetchContent)
+
 # --------------------------------------------------------------------
 
 set(CMAKE_CXX_STANDARD 20)
@@ -13,7 +15,18 @@ add_compile_options(-Wall -Wextra -g -Og -fsanitize=undefined)
 
 # --------------------------------------------------------------------
 
-find_package(fmt REQUIRED)
+find_package(fmt)
+
+if (NOT fmt_FOUND)
+
+  FetchContent_Declare(fmt
+    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+    GIT_TAG master
+  )
+
+  FetchContent_MakeAvailable(fmt)
+
+endif (NOT fmt_FOUND)
 
 # find_package(Catch2 2 REQUIRED)
 


### PR DESCRIPTION
Fmt is one of the dependencies, without it code won't compile. So, I decided, it will be a lot more convient for user to download fmt in case it is not found on his system. 

Besides, when I tried to install fmt via `sudo apt install libfmt-dev` command execution on my Ubuntu machine, I got an error just like this - https://github.com/fmtlib/fmt/issues/2769. Code didn't compiled because of it. 
This error is fixed in newer versions of fmt, but version inside apt is pretty old.
My fix will make occurrence of error above almost imposible, because cmake will install fmt from master branch of fmt repository. 